### PR TITLE
changed working directory to fix problem with no-ouput commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get -y upgrade && \
          python-numpy python-scipy python-pandas ttf-bitstream-vera
 
 # add code
-RUN mkdir /scripts
+RUN mkdir /scripts && mkdir analyses
 COPY scripts /scripts
 
 MAINTAINER Krzysztof Polanski <k.t.polanski@warwick.ac.uk>
@@ -18,6 +18,8 @@ MAINTAINER Krzysztof Polanski <k.t.polanski@warwick.ac.uk>
 #set up analysis crash text file
 RUN apt-get -y install git
 RUN git clone https://github.com/cyversewarwick/analysis_crash.git
+
+WORKDIR analyses
 
 # this is where we start
 ENTRYPOINT ["bash", "/scripts/ocsi_tarwrapper.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 #   docker build -t ocsi .
 
 # base everything on a recent Ubuntu
-FROM debian:latest
+FROM debian:9
 
 # get system packages up to date then install a basic scientific python
 RUN apt-get update && apt-get -y upgrade && \

--- a/scripts/ocsi_tarwrapper.sh
+++ b/scripts/ocsi_tarwrapper.sh
@@ -3,15 +3,9 @@ set -e
 
 cp /analysis_crash/WhyDidTheAnalysisCrash.txt .
 
-#mark start
-sleep 5
-touch tempfile
-sleep 5
-
 #run thing
 python /scripts/ocsi2.py "${@:1}"
 
 #wrap up output and kick out tempfile
-find . -mindepth 1 -newer tempfile -exec tar -rf FullOutput.tar {} \;
-rm tempfile
+tar -rf FullOutput.tar *
 rm WhyDidTheAnalysisCrash.txt


### PR DESCRIPTION
When running the container without additional arguments, --help is given, but the python script doesn't output anything. This (which can happen in case of failing job too) results in a bunch of system files being updated after the temporary file which is currently being created as a mean to identify the output files in /.
In non interactive mode this require the user to manually forcibly stop the container and hide the output in a long list of errors.
I suggest the easiest solution is probably to simplify the logic of the wrapper and just run the entrypoint command in a special empty directory (new working directory in the docker file).